### PR TITLE
Add sequential downloading option

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,17 +1,37 @@
 flag = false;
 filename = '';
+let listenerInstance = undefined;
+
+// It's already assumed, that when using this function, we're in sync. download
+// mode, which implies that no more than one download is present, thus no need to
+// to check for the finished download ID
+var onChangeFactory = responseCb => ({ state }) => {
+  if (state && state.current === "complete" && state.previous === "in_progress") {
+    chrome.downloads.onChanged.removeListener(listenerInstance);
+    responseCb({ actionStatus: "File downloaded successfully" });
+  }
+};
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
-  if (request.action == 'download') {
+  if (request.action === 'download' || request.action === 'download-sync') {
     filename = request.filename;
     flag = true;
     try {
       chrome.downloads.download({
         url: request.link,
       });
-      sendResponse({
-        actionStatus: 'File: ' + filename + ' downloaded'
-      });
+
+      if (request.action === "download-sync") {
+        listenerInstance = onChangeFactory(sendResponse)
+        chrome.downloads.onChanged.addListener(listenerInstance);
+        // This is used to send the response asynchronously,
+        // check: https://developer.chrome.com/extensions/messaging
+        return true;
+      } else {
+        sendResponse({
+          actionStatus: 'File: ' + filename + ' downloaded'
+        });
+      }
     } catch (err) {
       alert('Error: ' + err.message);
     }

--- a/script.js
+++ b/script.js
@@ -1,4 +1,5 @@
 var count = 0;
+var shouldBeSequential = false;
 
 Number.prototype.myPadding = function () {
   var number = this.valueOf();
@@ -13,7 +14,7 @@ Number.prototype.myPadding = function () {
 function getVideoSrc(){
   var link = $('#vjs_video_3_html5_api');
   if(!link.length){
-    //try fix get src error(domId changed) 
+    //try fix get src error(domId changed)
     link = $('video');
   }
   return link.attr('src');
@@ -93,7 +94,7 @@ function downloadAllVideos() {
   var finalFileName = $('section:last').find('li:last').find('h3').text();
 
   chrome.runtime.sendMessage({
-      action: 'download',
+      action: shouldBeSequential? 'download-sync': 'download',
       link: link,
       filename: saveFilePath
     },
@@ -103,8 +104,10 @@ function downloadAllVideos() {
         alert("Full Course Downloaded!");
       } else {
         $('#next-control').click();
-        setTimeout(pauseVideo, pauseVideoTimeout);
-        setTimeout(downloadAllVideos, downloadAllVideosTimeout);
+        // Use less timeout in sequential mode, since the
+        // response is  already async.
+        setTimeout(pauseVideo, shouldBeSequential? pauseVideoTimeout / 2 : pauseVideoTimeout);
+        setTimeout(downloadAllVideos, shouldBeSequential? downloadAllVideosTimeout / 3 :  downloadAllVideosTimeout);
       }
     }
   );
@@ -119,6 +122,8 @@ $(function () {
     } else if (e.which === 97 || e.which === 65) {
       // keypress `a`
       count = 0;
+      shouldBeSequential = confirm('Do you want your downloads to be sequential?');
+
       console.log('a => all');
       downloadAllVideos();
     }


### PR DESCRIPTION
This is the feature discussed in #11 
If sequential mode is selected, I adjusted the periods as follows (since there's already time taken during the download): 
- Video pause: 4 seconds
- Next download : 10 seconds

### Missing : 
Some sort of documentation in the README, briefly discussing the behavior of `sequential downloads`.